### PR TITLE
Add hover text to footer links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,6 +10,7 @@
 {{- range $menus }}
 {{ $url := partial "functions/getmenuurl.html" (dict "pctx" $pctx "entry" .) }}
 <a href="{{- $url -}}"
+   title="{{- or (i18n (upper .Identifier)) .Name | safeHTML -}}"
     {{ with .Params.targetBlank }}target="_blank"{{ end -}}
 >
     {{- with .Params.iconClass }}


### PR DESCRIPTION
This is an important accessibility feature for people who can't read icons.